### PR TITLE
fix: use mktemp to prevent /tmp race condition in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,10 +31,10 @@ WRAPPEREOF
 
 # Replace placeholder with actual path
 WRAPPER="${WRAPPER/COREPATH/$SCRIPT_DIR/scripts/core.py}"
-echo "$WRAPPER" > /tmp/ask-search-wrapper
-
-install -m 755 /tmp/ask-search-wrapper "$INSTALL_BIN/ask-search"
-rm -f /tmp/ask-search-wrapper
+TMPFILE=$(mktemp)
+echo "$WRAPPER" > "$TMPFILE"
+install -m 755 "$TMPFILE" "$INSTALL_BIN/ask-search"
+rm -f "$TMPFILE"
 echo "✓ ask-search installed to $INSTALL_BIN/ask-search"
 
 # Test


### PR DESCRIPTION
## 问题

install.sh 使用固定路径 `/tmp/ask-search-wrapper` 作为临时文件，存在 TOCTOU（time-of-check-time-of-use）竞态条件。攻击者可在写入和 install 之间通过 symlink 替换文件内容，将恶意脚本安装到 `/usr/local/bin/`。

## 修复

将固定 `/tmp/ask-search-wrapper` 替换为 `mktemp` 生成的随机临时文件，消除 symlink attack 向量。

## 改动

```diff
-echo "$WRAPPER" > /tmp/ask-search-wrapper
-install -m 755 /tmp/ask-search-wrapper "$INSTALL_BIN/ask-search"
-rm -f /tmp/ask-search-wrapper
+TMPFILE=$(mktemp)
+echo "$WRAPPER" > "$TMPFILE"
+install -m 755 "$TMPFILE" "$INSTALL_BIN/ask-search"
+rm -f "$TMPFILE"
```