### PR TITLE
fix: use mktemp to prevent /tmp race condition

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,10 +31,13 @@ WRAPPEREOF
 
 # Replace placeholder with actual path
 WRAPPER="${WRAPPER/COREPATH/$SCRIPT_DIR/scripts/core.py}"
-echo "$WRAPPER" > /tmp/ask-search-wrapper
 
-install -m 755 /tmp/ask-search-wrapper "$INSTALL_BIN/ask-search"
-rm -f /tmp/ask-search-wrapper
+# Use mktemp to prevent /tmp race condition
+WRAPPER_FILE=$(mktemp)
+echo "$WRAPPER" > "$WRAPPER_FILE"
+
+install -m 755 "$WRAPPER_FILE" "$INSTALL_BIN/ask-search"
+rm -f "$WRAPPER_FILE"
 echo "✓ ask-search installed to $INSTALL_BIN/ask-search"
 
 # Test


### PR DESCRIPTION
## Summary
- Use mktemp to create unique temp file instead of hardcoded path
- Prevents potential race condition if another process creates /tmp/ask-search-wrapper
- Follows security best practices for temporary file handling

## Security Note
This fix addresses a potential TOCTOU (time-of-check to time-of-use) race condition in the install script.